### PR TITLE
Allow IntelliJ IDEA 2020.1:* in plugin metadata

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ patchPluginXml {
     // [1]: https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html
     // [2]: https://www.jetbrains.com/idea/download/other.html
     sinceBuild "192.6262.58"
-    untilBuild "193.*"
+    untilBuild "201.*"
 }
 
 apply plugin: 'scala'


### PR DESCRIPTION
@Jazzpirate IntelliJ IDEA 2020.1 is out of early-access preview and people start using it, esp. in some courses by Florian. Could you check whether it works and make a release then? Perhaps just some minor release to keep in sync with MMT major versions.